### PR TITLE
Update cmake config for avr builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,18 +58,19 @@ add_compile_options( ${GCC_DEBUG_OPTIONS}
 # taken from 
 #:wgithub.com/mkleemann/cmake-avr/blob/master/CMakeLists.txt.sample
 # compiler options for all build types
-add_definitions("-DF_CPU=8000")
-add_definitions("-fpack-struct")
-add_definitions("-fshort-enums")
+add_definitions( "-DF_CPU=8000")
+add_definitions( "-fpack-struct")
+add_definitions( "-fshort-enums")
 #add_definitions("-Wall")
 #add_definitions("-Werror")
 #add_definitions("-pedantic")
 #add_definitions("-pedantic-errors")
-add_definitions("-funsigned-char")
-add_definitions("-funsigned-bitfields")
-add_definitions("-ffunction-sections")
-add_definitions("-c")
-add_definitions("-std=gnu99") 
+add_definitions( "-funsigned-char" )
+add_definitions( "-funsigned-bitfields" )
+add_definitions( "-ffunction-sections" )
+add_definitions( "-c" )
+add_definitions( "-std=gnu99" ) 
+add_definitions( "-mmcu=atmega8" )
 
 
 if ( BUILD_DOCS )
@@ -88,5 +89,5 @@ add_executable( kraken_test
 
 
 if ( BUILD_AVR ) 
-    target_link_libraries( kraken_test "m" "c" )
+    target_link_libraries( kraken_test "m" "c" "g" )
 endif()

--- a/kraken_demo.c
+++ b/kraken_demo.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 
 
-KRAKEN_THREAD_FUNCTION( t1,
+KRAKEN_AVR_THREAD_FUNCTION( t1,
 {
     static int i = 0;
     for ( ; i < 10; i++ ) 
@@ -18,7 +18,7 @@ KRAKEN_THREAD_FUNCTION( t1,
 })
 
 
-KRAKEN_THREAD_FUNCTION( t2,
+KRAKEN_AVR_THREAD_FUNCTION( t2,
 {
     static int i = 0; 
     for (; i < 10; i++ ) 

--- a/kraken_test.c
+++ b/kraken_test.c
@@ -1,5 +1,7 @@
+#define KRAKEN_DEBUG
+#define KRAKEN_SCHEDULER   0x01
+#define KRAKEN_MAX_THREADS 0x04
 #include "kraken.h"
-//#include <gtest/gtest.h>
 
 
 int main
@@ -7,8 +9,6 @@ int main
     void
 )
 {
-    //testing::InitGoogleTest(&argc, argv);
-    //return RUN_ALL_TESTS();
 }
 
 


### PR DESCRIPTION
1. Add gcc compile flags for avr cpu with an 8Mhz clock speed
2. Add linker libs for avr-gcc